### PR TITLE
Itext 7.2 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,5 +224,11 @@
 			<version>master-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.17.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -129,42 +129,42 @@
 	    <dependency>
 	        <groupId>com.itextpdf</groupId>
 	        <artifactId>kernel</artifactId>
-	        <version>7.1.14</version>
+	        <version>7.2.1</version>
 	        <scope>compile</scope>
 			<optional>false</optional>
 	    </dependency>
 	    <dependency>
 	        <groupId>com.itextpdf</groupId>
 	        <artifactId>io</artifactId>
-	        <version>7.1.14</version>
+	        <version>7.2.1</version>
 	        <scope>compile</scope>
 			<optional>false</optional>
 	    </dependency>
 	    <dependency>
 	        <groupId>com.itextpdf</groupId>
 	        <artifactId>layout</artifactId>
-	        <version>7.1.14</version>
+	        <version>7.2.1</version>
 	        <scope>compile</scope>
 			<optional>false</optional>
 	    </dependency>
 		<dependency>
 	        <groupId>com.itextpdf</groupId>
 	        <artifactId>pdfa</artifactId>
-	        <version>7.1.14</version>
+	        <version>7.2.1</version>
 	        <scope>compile</scope>
 			<optional>false</optional>
 	    </dependency>
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>forms</artifactId>
-			<version>7.1.14</version>
+			<version>7.2.1</version>
 			<scope>compile</scope>
 			<optional>false</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.itextpdf</groupId>
 			<artifactId>svg</artifactId>
-			<version>7.1.14</version>
+			<version>7.2.1</version>
 			<scope>compile</scope>
 			<optional>false</optional>
 		</dependency>

--- a/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernFontRecipient.java
+++ b/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernFontRecipient.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import com.itextpdf.io.font.constants.FontStyles;
 import com.itextpdf.kernel.font.PdfFont;
 import com.itextpdf.kernel.font.PdfFontFactory;
+import com.itextpdf.kernel.font.PdfFontFactory.EmbeddingStrategy;
 
 import net.sf.jasperreports.engine.JRRuntimeException;
 import net.sf.jasperreports.export.pdf.FontRecipient;
@@ -61,7 +62,8 @@ public class ModernFontRecipient implements FontRecipient
 	{
 		try
 		{
-			PdfFont pdfFont = PdfFontFactory.createRegisteredFont(pdfFontName, pdfEncoding, isPdfEmbedded, 
+			PdfFont pdfFont = PdfFontFactory.createRegisteredFont(pdfFontName, pdfEncoding, 
+					isPdfEmbedded ? EmbeddingStrategy.PREFER_EMBEDDED : EmbeddingStrategy.PREFER_NOT_EMBEDDED,
 					toITextFontStyle(pdfFontStyle));
 			
 			// check if FontFactory didn't find the font

--- a/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernPdfProducer.java
+++ b/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernPdfProducer.java
@@ -69,8 +69,8 @@ import com.itextpdf.layout.Document;
 import com.itextpdf.layout.element.Image;
 import com.itextpdf.layout.element.Paragraph;
 import com.itextpdf.layout.element.Text;
-import com.itextpdf.layout.property.OverflowPropertyValue;
-import com.itextpdf.layout.property.Property;
+import com.itextpdf.layout.properties.OverflowPropertyValue;
+import com.itextpdf.layout.properties.Property;
 import com.itextpdf.layout.splitting.ISplitCharacters;
 import com.itextpdf.svg.converter.SvgConverter;
 

--- a/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernPdfUtils.java
+++ b/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernPdfUtils.java
@@ -20,7 +20,7 @@ package com.jaspersoft.jasperreports.export.pdf.modern;
 
 import com.itextpdf.kernel.colors.Color;
 import com.itextpdf.kernel.colors.DeviceRgb;
-import com.itextpdf.layout.property.TextAlignment;
+import com.itextpdf.layout.properties.TextAlignment;
 
 import net.sf.jasperreports.engine.JRRuntimeException;
 import net.sf.jasperreports.export.pdf.PdfTextAlignment;

--- a/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernPhrase.java
+++ b/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/ModernPhrase.java
@@ -20,7 +20,7 @@ package com.jaspersoft.jasperreports.export.pdf.modern;
 
 import com.itextpdf.layout.element.ILeafElement;
 import com.itextpdf.layout.element.Paragraph;
-import com.itextpdf.layout.property.BaseDirection;
+import com.itextpdf.layout.properties.BaseDirection;
 
 import net.sf.jasperreports.engine.JRRuntimeException;
 import net.sf.jasperreports.export.pdf.PdfChunk;

--- a/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/PdfFontCache.java
+++ b/src/main/java/com/jaspersoft/jasperreports/export/pdf/modern/PdfFontCache.java
@@ -26,7 +26,7 @@ import com.itextpdf.io.font.FontProgram;
 import com.itextpdf.io.font.FontProgramFactory;
 import com.itextpdf.kernel.font.PdfFont;
 import com.itextpdf.kernel.font.PdfFontFactory;
-
+import com.itextpdf.kernel.font.PdfFontFactory.EmbeddingStrategy;
 import net.sf.jasperreports.engine.JRRuntimeException;
 
 /**
@@ -86,7 +86,7 @@ public class PdfFontCache
 			FontProgram fontProgram = getCachedFontProgram(fontKey);
 			if (fontProgram != null)
 			{
-				pdfFont = PdfFontFactory.createFont(fontProgram, pdfEncoding, isPdfEmbedded);
+				pdfFont = PdfFontFactory.createFont(fontProgram, pdfEncoding, isPdfEmbedded ? EmbeddingStrategy.PREFER_EMBEDDED : EmbeddingStrategy.PREFER_NOT_EMBEDDED);
 				pdfFont = cacheFont(fontKey, pdfFont);
 			}
 		}
@@ -111,7 +111,7 @@ public class PdfFontCache
 			fontProgram = cacheFontProgram(fontKey, fontProgram);
 		}
 		
-		PdfFont pdfFont = PdfFontFactory.createFont(fontProgram, pdfEncoding, isPdfEmbedded);
+		PdfFont pdfFont = PdfFontFactory.createFont(fontProgram, pdfEncoding, isPdfEmbedded ? EmbeddingStrategy.PREFER_EMBEDDED : EmbeddingStrategy.PREFER_NOT_EMBEDDED);
 		pdfFont = cacheFont(fontKey, pdfFont);
 		return pdfFont;
 	}


### PR DESCRIPTION
itext 7.2 has introduced some breaking changes
this PR is to fix the upgrade issues

- package rename
com.itextpdf.layout.property -> com.itextpdf.layout.properties

- use of EmbeddingStrategy vs boolean for embedding font